### PR TITLE
Fix "TypeError: recBuffers.push is undefined"

### DIFF
--- a/lib/WebAudioRecorderMp3.js
+++ b/lib/WebAudioRecorderMp3.js
@@ -36,13 +36,15 @@ function start(bufferSize) {
 }
 
 function record(buffer) {
-  if (bufferCount++ < maxBuffers)
-    if (encoder)
+  if (bufferCount++ < maxBuffers) {
+    if (encoder) {
       encoder.encode(buffer);
-    else
+    } else if (recBuffers) {
       recBuffers.push(buffer);
-  else
+     }
+  } else {
     self.postMessage({ command: "timeout" });
+  }
 };
 
 function postProgress(progress) {

--- a/lib/WebAudioRecorderOgg.js
+++ b/lib/WebAudioRecorderOgg.js
@@ -34,13 +34,15 @@ function start(bufferSize) {
 }
 
 function record(buffer) {
-  if (bufferCount++ < maxBuffers)
-    if (encoder)
+  if (bufferCount++ < maxBuffers) {
+    if (encoder) {
       encoder.encode(buffer);
-    else
+    } else if (recBuffers) {
       recBuffers.push(buffer);
-  else
+     }
+  } else {
     self.postMessage({ command: "timeout" });
+  }
 };
 
 function postProgress(progress) {

--- a/lib/WebAudioRecorderWav.js
+++ b/lib/WebAudioRecorderWav.js
@@ -34,13 +34,15 @@ function start(bufferSize) {
 }
 
 function record(buffer) {
-  if (bufferCount++ < maxBuffers)
-    if (encoder)
+  if (bufferCount++ < maxBuffers) {
+    if (encoder) {
       encoder.encode(buffer);
-    else
+    } else if (recBuffers) {
       recBuffers.push(buffer);
-  else
+     }
+  } else {
     self.postMessage({ command: "timeout" });
+  }
 };
 
 function postProgress(progress) {


### PR DESCRIPTION
The function 'record' might throw a TypeError when executing `recBuffers.push`.

This happens when stopping the recorder, there is a chance for a race condition in the last 'record' event call and clean method, the clean method assigns the recBuffers to null, record event might be executing after the clean method, and then throw type error because recBuffers isn't defined.

The fix is to check if the recBuffers is undefined before accessing that var.